### PR TITLE
[HNC-522] : Updating Change Detection tag to stable

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -141,7 +141,7 @@ jobs:
       - name: Determine which changes occurred
         if: ${{ inputs.modules_to_build == '' }}
         id: change_detection
-        uses: hv-actions/change-detection-builder@1.0.1
+        uses: hv-actions/change-detection-builder@stable
 
       - name: Build code and deploy artifacts
         uses: lumada-common-services/gh-composite-actions@stable
@@ -177,7 +177,7 @@ jobs:
       - name: Determine which changes occurred
         if: ${{ inputs.modules_to_build == '' }}
         id: change_detection
-        uses: hv-actions/change-detection-builder@1.0.1
+        uses: hv-actions/change-detection-builder@stable
 
       - name: Determine version
         id: version

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Determine which changes occurred
         id: change_detection
-        uses: hv-actions/change-detection-builder@1.0.1
+        uses: hv-actions/change-detection-builder@stable
 
       - name: Build the project
         uses: lumada-common-services/gh-composite-actions@stable


### PR DESCRIPTION
Changed the detection action tag to point to the `stable` (i.e., 1.2.0) version to address the issue where changes to the release manifest file in the **.github** folder triggered a full build from the root. This latest version will ignore all changes made in the `.github` folder, including all `yaml/yml` files.