### PR TITLE
[HNC-523] - Reduce logs verbosity in reusable release workflow.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,11 @@ on:
         type: boolean
         default: true
         description: "Promote artifacts in Artifactory."
+      logging_level:
+        type: string
+        default: INFO
+        required: false 
+        description: "Sets the logging level to get more detailed info."  
 
 env:
   ARTIFACTORY_HOST: ${{ inputs.arti_host }}
@@ -152,7 +157,8 @@ jobs:
           --manifest_file_path ${{ env.MANIFEST_PATH}} \
           --rt_base_url ${{ env.ARTIFACTORY_BASE_URL }} \
           --jf_cli_rt_name ${{ inputs.jf_cli_rt_name }} \
-          --dry_run ${{ inputs.dry_run }}
+          --dry_run ${{ inputs.dry_run }} \
+          --logging_level ${{inputs.logging_level }}
 
       - name: Set Box Summary
         if: ${{ inputs.box_upload == true }}


### PR DESCRIPTION
Adjusted the reusable release workflow configuration to minimize the log's verbosity during execution. This change helps produce a more concise and cleaner output, improving readability.

Output After Changing Python Script:- 
1. When the logging level is set to `INFO`  [link](https://github.com/pentaho/pdi-plugins-ee/actions/runs/7346463412/job/20001261137#step:11:37).
2. When the logging level is set to `DEBUG` [link](https://github.com/pentaho/pdi-plugins-ee/actions/runs/7347126733/job/20003021384#step:11:37).

Note:-  Both scenarios were tested in a dry run condition.