### PR TITLE
[HNC-561] : Update new cmd tracking changes in actions-common

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -227,9 +227,9 @@ jobs:
               -amd
         env:
           cmd_type: UNIT_TEST
-          reporter: 'java-junit'
-          fail-on-error: 'true'
-          test_report_path: '**/target/surefire-reports/*.xml'
+          unit_test_reporter: 'java-junit'
+          unit_test_fail_on_error: 'true'
+          unit_test_report_path: '**/target/surefire-reports/*.xml'
 
       - name: Run PDI plugin integration tests
         uses: pentaho/actions-common@stable

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -128,9 +128,9 @@ jobs:
             -pl "${{ format('{0},{1}', inputs.modules_to_always_build_in_addition_to_those_with_changes, steps.change_detection.outputs.changed_modules) }}"
         env:
           cmd_type: UNIT_TEST
-          reporter: 'java-junit'
-          fail-on-error: 'true'
-          test_report_path: '**/target/surefire-reports/*.xml'
+          unit_test_reporter: 'java-junit'
+          unit_test_fail_on_error: 'true'
+          unit_test_report_path: '**/target/surefire-reports/*.xml'
 
       - name: Run PDI plugin integration tests
         uses: pentaho/actions-common@stable

--- a/action.yml
+++ b/action.yml
@@ -48,9 +48,9 @@ runs:
       uses: lumada-common-services/gh-composite-actions@stable
       env:
         cmd_type: INTEGRATION_TEST
-        test_report_path: '**/target/failsafe-reports/TEST*.xml'
-        reporter: 'java-junit'
-        fail-on-error: 'true'
+        int_test_report_path: '**/target/failsafe-reports/TEST*.xml'
+        int_test_reporter: 'java-junit'
+        int_test_fail_on_error: 'true'
       with:
         command: |
           actions-common/.github/scripts/sh/run-pdi-plugin-integration-tests.sh \


### PR DESCRIPTION
Updating environmental names for the `Unit Test` and `Integration Test` steps according to the new changes in command tracking in gh-composite-actions.