### PR TITLE
[ BACKLOG-44143 ] - Create github actions to run sonarqube on new repo https://github.com/pentaho/spark-execution [Added resolve repo for custom artifacts]

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -78,6 +78,10 @@ on:
         required: false
         description: 'Image to be used'
         type: string
+      resolve_repo:
+        required: false
+        type: string
+        description: "Custom Maven repo for dependency resolution"
     outputs:
       current-version:
         description: "The current version being built"
@@ -95,7 +99,7 @@ env:
   ARTIFACTORY_HOST: https://${{ vars.ARTIFACTORY_HOST }}
   ARTIFACTORY_BASE_URL: ${ARTIFACTORY_HOST}/artifactory
 
-  RESOLVE_REPO_MIRROR: ${ARTIFACTORY_BASE_URL}/pnt-mvn
+  RESOLVE_REPO_MIRROR: ${{ format('{0}/{1}', vars.ARTIFACTORY_BASE_URL, inputs.resolve_repo || 'pnt-mvn') }}
 
   NEXUS_DEPLOY_USER: ${{ secrets.PENTAHO_CICD_ONE_USER }}
   NEXUS_DEPLOY_PASSWORD: ${{ secrets.PENTAHO_CICD_ONE_KEY }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,6 +24,10 @@ on:
         required: false
         description: 'Image to be used'
         type: string
+      resolve_repo:
+        required: false
+        type: string
+        description: "Custom Maven repo for dependency resolution"
 
 
 env:
@@ -34,7 +38,7 @@ env:
   ARTIFACTORY_HOST: https://${{ vars.ARTIFACTORY_HOST }}
   ARTIFACTORY_BASE_URL: ${ARTIFACTORY_HOST}/artifactory
 
-  RESOLVE_REPO_MIRROR: ${ARTIFACTORY_BASE_URL}/pnt-mvn
+  RESOLVE_REPO_MIRROR: ${{ format('{0}/{1}', vars.ARTIFACTORY_BASE_URL, inputs.resolve_repo || 'pnt-mvn') }}
 
   NEXUS_DEPLOY_USER: ${{ secrets.PENTAHO_CICD_ONE_USER }}
   NEXUS_DEPLOY_PASSWORD: ${{ secrets.PENTAHO_CICD_ONE_KEY }}


### PR DESCRIPTION
Test PRs and workflows performed on a private dev test repo similar to spark-execution


- PR - https://github.com/pentaho/dev-test-spark-execution/pull/20
- Merge workflow - [Merge pull request #20 from nawaz34-hitachivantara/test-sonar123 · pentaho/dev-test-spark-execution@8d1d4d0](https://github.com/pentaho/dev-test-spark-execution/actions/runs/17066684043)
- PR workflow - [test · pentaho/dev-test-spark-execution@30939c5](https://github.com/pentaho/dev-test-spark-execution/actions/runs/17065944070/job/48383002818)
- SonarQube - [dev-test-spark-execution - Overview - SonarQube](https://sonar.orl.eng.hitachivantara.com/dashboard?id=dev-test-spark-execution&pullRequest=20)